### PR TITLE
Support for LaCrosse Dual Temperature sensors like Technoline TX25-IT

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -221,7 +221,7 @@
 
     <h4 class="translate">Sensor configuration</h4>
     <p class="translate">valid sensor types:</p>
-    <p> emonTH, emonWater, LaCrosseDTH, LaCrosseBMP180</p>  <!--solange es noch kein select in der Tabelle gibt -->
+    <p> emonTH, emonWater, LaCrosseDTH, LaCrosseDTT, LaCrosseBMP180</p>  <!--solange es noch kein select in der Tabelle gibt -->
     <table id="sensors"></table><div id="pager-sensors"></div>
 
 </div>

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -18,6 +18,7 @@
                 'emonTH',
                 'emonWater',
                 'LaCrosseDTH',
+                'LaCrosseDTT',
                 'LaCrosseBMP180',
                 'HMS100TF',
                 'LaCrosseWS',
@@ -177,7 +178,7 @@
                 <div class="col s12">
                     <h6 class="translate sub-title">Sensor configuration</h6>
                     <p class="translate">valid sensor types:</p>
-                    <p> emonTH, emonWater, LaCrosseDTH, LaCrosseBMP180, HMS100T, LaCrosseWS, EC3000, EMT7110, level</p>
+                    <p> emonTH, emonWater, LaCrosseDTH, LaCrosseDTT, LaCrosseBMP180, HMS100T, LaCrosseWS, EC3000, EMT7110, level</p>
                 </div>
             </div>
             <div class="col s12" id="values">
@@ -200,7 +201,7 @@
                             <tr>
                                 <th data-name="_index" style="width: 40px" class="translate"></th>
                                 <th data-name="sid" style="width: 40px" class="translate">id</th>
-                                <th data-name="stype" style="width: 150px" class="translate" data-options="emonTH;emonWater;LaCrosseDTH;LaCrosseBMP180;HMS100TF;LaCrosseWS;EC3000;EMT7110;level" data-type="select">type</th>
+                                <th data-name="stype" style="width: 150px" class="translate" data-options="emonTH;emonWater;LaCrosseDTH;LaCrosseDTT;LaCrosseBMP180;HMS100TF;LaCrosseWS;EC3000;EMT7110;level" data-type="select">type</th>
                                 <th data-name="usid" style="width: 50px" class="translate">uid</th>
                                 <th data-name="name" style="width: 200px" class="translate">name</th>
                                 <th data-buttons="delete" style="width: 40px" class="translate">delete</th>


### PR DESCRIPTION
This changes add support for a variant of LaCrosseDTH sensors which have 2 temperature sensors and no humidity sensor (like 'Technoline TX25-IT'). This data bytes of this sensor looks the same like LaCrosseDTH , but uses the 'Sensor type' field for marking the temperature channels:

```
2019-07-28 17:15:01.423  - info: jeelink.0 data received: OK 9 30 130 5 18 125
2019-07-28 17:15:05.657  - info: jeelink.0 data received: OK 9 30 1 4 219 106
```

For configuration and usage of such a sensor simply select 'LaCrosseDTT' as Sensor Type and the rest like any other LaCrosseDTH sensor.