### PR TITLE
fixed adapter crash, because of wrong type of baudRate config

### DIFF
--- a/main.js
+++ b/main.js
@@ -67,7 +67,7 @@ class Jeelink extends utils.Adapter {
 		}
 
 		var options = {
-			baudRate: this.config.baudrate || 57600
+			baudRate: parseInt(this.config.baudrate || 57600)
 		};
 		this.log.debug('configured port : ' + this.config.serialport);
 		this.log.debug('configured baudrate : ' + this.config.baudrate);


### PR DESCRIPTION
The adapter crashed after updating ioBroker to js.controller v. 4.0.23 and admin to 5.3.8. The error was, that the baudrate was string value and a number value was expected. So I convert the value while setting the options. 